### PR TITLE
Correct calculation of cost

### DIFF
--- a/app/views/pages/my_bookings.html.erb
+++ b/app/views/pages/my_bookings.html.erb
@@ -17,8 +17,9 @@
           <div class="card-product-infos">
             <h2><%= booking.flat.name %></h2>
             <p><strong>Check in: </strong><%= booking.start_date %> &nbsp; <strong>Check out: </strong> <%= booking.end_date %></p>
-            <% no_of_nights = booking.end_date - booking.start_date %>
-            <% cost = booking.flat.price * no_of_nights %>
+            <% no_of_nights = booking.end_date > booking.start_date ? booking.end_date - booking.start_date : 1 %>
+            <% no_of_guests = booking.adults + booking.children %>
+            <% cost = booking.flat.price * no_of_nights.to_i * no_of_guests.to_i %>
             <p><strong>Number of nights: </strong> <%= no_of_nights.to_i %> &nbsp; <strong>Estimated cost: </strong> <%= '€'+number_with_precision(cost, precision: 2) %></p>
             <div class="my-2">
               <%= link_to "Cancel Reservation", booking_path(booking), class: "blue-btn", data: { turbo_method: :delete, turbo_confirm: "You are cancelling your booking reservation at #{booking.flat.name}" }  %>


### PR DESCRIPTION
Corrected two errors in the calculation of cost of stay:

- Number of guests were not included previously in the equation (Adults + Children)
- If booking start date is same as booking end date (one night stay). Number of nights gave a result of zero, instead of desired one night. This was corrected with a ternary operator.